### PR TITLE
Set working directory for the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ RUN apk --no-cache update && \
     apk --no-cache add python py-pip py-setuptools ca-certificates groff less && \
     pip --no-cache-dir install awscli && \
     rm -rf /var/cache/apk/*
+
+WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ output:
     2014-06-03 19:41:30 folder1
     2014-06-06 23:02:29 folder2
 
+### Upload content of your current directory (say it contains two files _test.txt_ and _test2.txt_) to s3 bucket
+
+    docker run \
+    --env AWS_ACCESS_KEY_ID=<<YOUR_ACCESS_KEY>> \
+    --env AWS_SECRET_ACCESS_KEY=<<YOUR_SECRET_ACCESS>> \
+    -v $PWD:/data
+    garland/aws-cli-docker \
+    aws s3 --dryrun sync . s3://mybucket
+
+output:
+
+    (dryrun) upload: test.txt to s3://mybucket/test.txt
+    (dryrun) upload: test2.txt to s3://mybucket/test2.txt
+
 doc: http://docs.aws.amazon.com/cli/latest/reference/s3/index.html
 
 ### Retrieve a decrypted Windows password by passing in your private key


### PR DESCRIPTION
By setting working directory of the container to **/data** allows seamlessly map local directory to **/data** and eliminate unnecessary paths.

In my experience **/data** is common location for storing data in the container.

As I mentioned in README it will make syncing process even more seamlessly by mapping current working directory or any other to s3 bucket:

```
docker run \
    --env AWS_ACCESS_KEY_ID=<<YOUR_ACCESS_KEY>> 
    --env AWS_SECRET_ACCESS_KEY=<<YOUR_SECRET_ACCESS>> \
    -v $PWD:/data
    garland/aws-cli-docker \
    aws s3 sync . s3://mybucket
```

In that case it allows me to create a function in *.zshrc* file:

```
aws() {
        docker run -i -t --rm --env AWS_ACCESS_KEY_ID=<<YOUR_ACCESS_KEY>> --env AWS_SECRET_ACCESS_KEY=<<YOUR_SECRET_ACCESS>> -v $PWD:/data garland/aws-cli-docker aws $*
}
```

And use it lie it:
```
> aws s3 sync . s3://mybucket
```